### PR TITLE
Add docs generation date in footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "typedoc": "0.23.26",
+        "typedoc-plugin-extras": "^2.3.2",
         "typescript": "4.9.5"
       }
     },
@@ -104,6 +105,15 @@
       },
       "peerDependencies": {
         "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+      }
+    },
+    "node_modules/typedoc-plugin-extras": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.3.2.tgz",
+      "integrity": "sha512-g2m8UuGgaD5lNKO6f1p3atEugtTEb/le8IYkAiksmGYZyyF44SvRe8NcaJLq61mC+XRHHszQ664v3Vw9avIrMw==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "0.23.x"
       }
     },
     "node_modules/typescript": {
@@ -204,6 +214,13 @@
         "minimatch": "^7.1.3",
         "shiki": "^0.14.1"
       }
+    },
+    "typedoc-plugin-extras": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.3.2.tgz",
+      "integrity": "sha512-g2m8UuGgaD5lNKO6f1p3atEugtTEb/le8IYkAiksmGYZyyF44SvRe8NcaJLq61mC+XRHHszQ664v3Vw9avIrMw==",
+      "dev": true,
+      "requires": {}
     },
     "typescript": {
       "version": "4.9.5",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {},
   "devDependencies": {
     "typedoc": "0.23.26",
+    "typedoc-plugin-extras": "^2.3.2",
     "typescript": "4.9.5"
   }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,6 @@
 {
   "entryPoints": ["./types/index.d.ts"],
   "disableSources": true,
-  "readme": "README.md"
+  "readme": "README.md",
+  "footerLastModified": true
 }


### PR DESCRIPTION
This PR adds a TypeDoc plugin to have the generation date in the footer of all pages of the generated documentation.
A small JS snippet is inserted and shows the elapsed time thanks to the `Intl.RelativeTimeFormat` API.

The result looks like this:

![image](https://user-images.githubusercontent.com/9317502/221413387-4f5995e9-5cf8-4c87-9700-61b06ce21027.png)